### PR TITLE
github logo is clipped on Firefox

### DIFF
--- a/stylesheets/zepto.css
+++ b/stylesheets/zepto.css
@@ -149,7 +149,7 @@ body.desktop #main_content {
   height:34px;
   margin:5px 0;
   text-indent:-5000px;
-  background-size: 100%;
+  background-size: contain;
   background:transparent url(../images/github-big.png) no-repeat;
   opacity:0.75;
 }


### PR DESCRIPTION
On Firefox 9.01 the github logo is clipped; its size scales in Chrome but didn't in Firefox. Setting `background-size: contain;` causes it to scale in both browsers.
